### PR TITLE
Update the crystal version in README

### DIFF
--- a/crystal/README.md
+++ b/crystal/README.md
@@ -4,7 +4,7 @@ This is an example of using the Crytal client of [Base API](https://www.base-api
 
 ## Requirements
 
-- [Crystal 0.30.1](https://crystal-lang.org)
+- [Crystal 0.31.0](https://crystal-lang.org)
 
 ## Installation
 


### PR DESCRIPTION
Shards.yml uses 0.31.0 so the README should reflect that.
https://github.com/base-api-io/base-examples/blob/b651823f424897db469180d6211e3630c6e18b24/crystal/shard.yml#L7